### PR TITLE
Make sure oc_xendit_order are filled

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This module has been tested against the following tech stacks:
 | 2.2.0 | Ubuntu 18.04.2 LTS | MariaDB 10.3 | 7.3 | Nginx 1.16.1 |
 | 2.3.0.2 | Ubuntu 18.04.2 LTS | MariaDB 10.3 | 7.3 | Nginx 1.16.1 |
 | 3.0.3.2 | Ubuntu 18.04.2 LTS | MariaDB 10.1.39 | 7.2.12 | Apache 2.4.37 |
+| 3.0.3.3 | Mac OSX | MariaDB 10.3 | 7.3 | Apache 2.4 |
 
 ### How to
 To install this plugin, you just need to copy all the content inside the correct version of your Opencart store (e.g. `opencart3.0.x/upload` for Opencart 3.0) folder to your root Opencart folder

--- a/opencart1.5.x/upload/admin/controller/payment/xendit.php
+++ b/opencart1.5.x/upload/admin/controller/payment/xendit.php
@@ -119,8 +119,6 @@ class ControllerPaymentXendit extends Controller
 		);
 				
         $this->response->setOutput($this->render());
-        
-        $this->cancelExpiredOrder();
     }
 
     public function install()
@@ -138,61 +136,6 @@ class ControllerPaymentXendit extends Controller
     public function validate()
     {
         return true;
-    }
-
-    public function cancelExpiredOrder()
-    {
-        $this->load->model('payment/xendit');
-        $this->load->model('sale/order');
-
-        $bulk_cancel_data = array();
-        $expired_orders = $this->model_payment_xendit->getExpiredOrders();
-
-        if ($expired_orders) {
-            foreach ($expired_orders as $xendit_order) {
-                $order_id = $xendit_order['order_id'];
-                $order = $this->model_sale_order->getOrder(
-                    $order_id
-                );
-    
-                $bulk_cancel_data[] = array(
-                    'id' => $xendit_order['xendit_invoice_id'],
-                    'expiry_date' => $xendit_order['xendit_expiry_date'],
-                    'order_number' => $order_id,
-                    'amount' => (int)$order['total']
-                );
-    
-                $this->model_payment_xendit->expireOrder($order_id);
-                $this->model_payment_xendit->addOrderHistory(
-                    $order,
-                    $order_id,
-                    7,
-                    'Order cancelled because Xendit invoice expired',
-                    false
-                );
-            }
-        }
-
-        if (!empty($bulk_cancel_data)) {
-            $response = $this->track_order_cancellation($bulk_cancel_data);
-        }
-    }
-
-    private function track_order_cancellation($payload)
-    {
-        $request_url = '/payment/xendit/invoice/bulk-cancel';
-        $request_payload = array(
-            'invoice_data' => json_encode($payload)
-        );
-        $request_options = array(
-            'store_name' => Xendit::DEFAULT_STORE_NAME
-        );
-
-        $api_key = $this->get_api_key();
-        Xendit::set_secret_key($api_key['secret_key']);
-
-        $response = Xendit::request($request_url, Xendit::METHOD_POST, $request_payload, $request_options);
-        return $response;
     }
 
     private function get_api_key()

--- a/opencart1.5.x/upload/admin/model/payment/xendit.php
+++ b/opencart1.5.x/upload/admin/model/payment/xendit.php
@@ -3,16 +3,18 @@
 class ModelPaymentXendit extends Model {
     public function install() {
         $this->db->query("CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "xendit_order` (
-            `xendit_invoice_id` varchar(255) NOT NULL PRIMARY KEY,
+            `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            `order_id` int(11) NOT NULL DEFAULT '0',
+            `external_id` varchar(255) NOT NULL,
+            `amount` decimal(10,2) NOT NULL,
+            `payment_method` varchar(255) NOT NULL,
+            `xendit_invoice_id` varchar(255) NOT NULL,
+            `xendit_invoice_fee` decimal(10,2) NOT NULL,
+            `xendit_charge_id` varchar(255) NOT NULL,
+            `xendit_paid_date` datetime NOT NULL,
             `xendit_expiry_date` datetime NOT NULL,
-            `status` varchar(255) NOT NULL,
-            `order_id` int(11) NOT NULL DEFAULT '0',
-            `environment` varchar(5) NOT NULL DEFAULT 'test'
-        ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
-
-        $this->db->query("CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "xendit_charge` (
-            `xendit_charge_id` varchar(255) NOT NULL PRIMARY KEY,
-            `order_id` int(11) NOT NULL DEFAULT '0',
+            `xendit_cancelled_date` datetime NOT NULL,
+            `status` varchar(150) NOT NULL,
             `environment` varchar(5) NOT NULL DEFAULT 'test'
         ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
     }

--- a/opencart1.5.x/upload/admin/model/payment/xendit.php
+++ b/opencart1.5.x/upload/admin/model/payment/xendit.php
@@ -33,29 +33,6 @@ class ModelPaymentXendit extends Model {
         }
     }
 
-    public function getOrderByInvoiceId($invoice_id) {
-        $query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "xendit_order` WHERE `xendit_invoice_id` = '" . $invoice_id . "' LIMIT 1");
-        if ($query->num_rows) {
-            return $query->row;
-        } else {
-            return false;
-        }
-    }
-
-    public function expireOrder($order_id) {
-        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` SET `status` = 'EXPIRED' WHERE `order_id` = '" . $order_id . "'");
-    }
-
-    public function getExpiredOrders() {
-        $query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "xendit_order` WHERE `xendit_expiry_date` < NOW() AND `status` = 'PENDING'");
-
-        if ($query->num_rows) {
-            return $query->rows;
-        } else {
-            return false;
-        }
-    }
-
     public function addOrderHistory($order_info, $order_id, $order_status_id, $comment = '') {
 		if ($order_info) {
 			// Update the DB with the new statuses

--- a/opencart1.5.x/upload/admin/model/payment/xendit.php
+++ b/opencart1.5.x/upload/admin/model/payment/xendit.php
@@ -4,16 +4,16 @@ class ModelPaymentXendit extends Model {
     public function install() {
         $this->db->query("CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "xendit_order` (
             `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
-            `order_id` int(11) NOT NULL DEFAULT '0',
+            `order_id` int(11) NOT NULL,
             `external_id` varchar(255) NOT NULL,
             `amount` decimal(10,2) NOT NULL,
             `payment_method` varchar(255) NOT NULL,
-            `xendit_invoice_id` varchar(255) NOT NULL,
-            `xendit_invoice_fee` decimal(10,2) NOT NULL,
-            `xendit_charge_id` varchar(255) NOT NULL,
-            `xendit_paid_date` datetime NOT NULL,
-            `xendit_expiry_date` datetime NOT NULL,
-            `xendit_cancelled_date` datetime NOT NULL,
+            `xendit_invoice_id` varchar(255),
+            `xendit_invoice_fee` decimal(10,2),
+            `xendit_charge_id` varchar(255),
+            `xendit_paid_date` datetime,
+            `xendit_expiry_date` datetime,
+            `xendit_cancelled_date` datetime,
             `status` varchar(150) NOT NULL,
             `environment` varchar(5) NOT NULL DEFAULT 'test'
         ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");

--- a/opencart1.5.x/upload/catalog/controller/payment/xendit.php
+++ b/opencart1.5.x/upload/catalog/controller/payment/xendit.php
@@ -54,8 +54,8 @@ class ControllerPaymentXendit extends Controller {
                 $json['error'] = $response['message'];
             }
             else {
+                $this->model_payment_xendit->addOrder($order, $response, $this->config->get('payment_xendit_environment'));
                 $message = 'Invoice ID: ' . $response['id'] . '. Redirecting..';
-                //$this->model_checkout_order->addOrder($order); //xendit add order
                 //Update order status to pending
                 $this->model_checkout_order->confirm(
                     $order_id,
@@ -146,8 +146,8 @@ class ControllerPaymentXendit extends Controller {
     private function process_order($response, $order_id) {
         if ($response['status'] === 'PAID' || $response['status'] === 'SETTLED') {
             $this->cart->clear();
-            $message = 'Payment successful. Invoice id: ' . $response['id'];
-            //$this->model_payment_xendit->completeOrder($order_id);
+            $message = 'Payment successful. Invoice ID: ' . $response['id'];
+            $this->model_payment_xendit->completeOrder($order_id);
 
             //Update order status to processing
             $this->model_checkout_order->update(
@@ -158,7 +158,7 @@ class ControllerPaymentXendit extends Controller {
             );
             $this->response->setOutput($message);
         } else {
-            $message = 'Invoice not paid or settled. Cancelling order. Charge id: ' . $response['id'];
+            $message = 'Invoice not paid or settled. Cancelling order. Charge ID: ' . $response['id'];
             return $this->cancel_order($order_id, $message);
         }
     }

--- a/opencart1.5.x/upload/catalog/controller/payment/xendit.php
+++ b/opencart1.5.x/upload/catalog/controller/payment/xendit.php
@@ -79,10 +79,10 @@ class ControllerPaymentXendit extends Controller {
             $this->load->model('payment/xendit');
             $this->load->model('checkout/order');
 
-            $response = json_decode(file_get_contents('php://input'), true);
-            $invoice_id = $response['id'];
-            $external_id = $response['external_id'];
-            $order_id = str_replace(self::EXT_ID_PREFIX, "", $external_id);
+            $original_response = json_decode(file_get_contents('php://input'), true);
+            $invoice_id = $original_response['id'];
+            $external_id = $original_response['external_id'];
+            $order_id = preg_replace('/[^0-9]/', '', $external_id);
             $order_info = $this->model_checkout_order->getOrder($order_id);
 
             if (empty($order_info)) {
@@ -120,7 +120,7 @@ class ControllerPaymentXendit extends Controller {
                     return;
                 }
 
-                return $this->process_order($response, $order_id);
+                return $this->process_order($response, $original_response, $order_id);
             } catch (Exception $e) {
                 echo 'something';
             }
@@ -143,11 +143,14 @@ class ControllerPaymentXendit extends Controller {
         }
     }
 
-    private function process_order($response, $order_id) {
+    private function process_order($response, $original_response, $order_id) {
         if ($response['status'] === 'PAID' || $response['status'] === 'SETTLED') {
             $this->cart->clear();
             $message = 'Payment successful. Invoice ID: ' . $response['id'];
-            $this->model_payment_xendit->completeOrder($order_id);
+
+            $this->model_payment_xendit->paidOrder($order_id, $response['paid_at'], array(
+                'xendit_invoice_fee' => $original_response['fees_paid_amount'])
+            );
 
             //Update order status to processing
             $this->model_checkout_order->update(
@@ -158,7 +161,7 @@ class ControllerPaymentXendit extends Controller {
             );
             $this->response->setOutput($message);
         } else {
-            $message = 'Invoice not paid or settled. Cancelling order. Charge ID: ' . $response['id'];
+            $message = 'Invoice not paid or settled. Cancelling order. Invoice ID: ' . $response['id'];
             return $this->cancel_order($order_id, $message);
         }
     }

--- a/opencart1.5.x/upload/catalog/controller/payment/xendit.php
+++ b/opencart1.5.x/upload/catalog/controller/payment/xendit.php
@@ -3,7 +3,7 @@
 require_once(DIR_SYSTEM . 'library/xendit.php');
 
 class ControllerPaymentXendit extends Controller {
-    const EXT_ID_PREFIX = 'xendit_opencart_';
+    const EXT_ID_PREFIX = 'opencart-xendit-';
 
     public function index() {
         $this->load->language('payment/xendit');

--- a/opencart1.5.x/upload/catalog/controller/payment/xendit.php
+++ b/opencart1.5.x/upload/catalog/controller/payment/xendit.php
@@ -54,7 +54,7 @@ class ControllerPaymentXendit extends Controller {
                 $json['error'] = $response['message'];
             }
             else {
-                $this->model_payment_xendit->addOrder($order, $response, $this->config->get('payment_xendit_environment'));
+                $this->model_payment_xendit->addOrder($order, $response, $this->config->get('payment_xendit_environment'), 'invoice');
                 $message = 'Invoice ID: ' . $response['id'] . '. Redirecting..';
                 //Update order status to pending
                 $this->model_checkout_order->confirm(
@@ -165,6 +165,7 @@ class ControllerPaymentXendit extends Controller {
 
     private function cancel_order($order_id, $message) {
         $this->cart->clear();
+        $this->model_payment_xendit->cancelOrder($order_id);
         $this->model_checkout_order->update(
             $order_id,
             7,

--- a/opencart1.5.x/upload/catalog/controller/payment/xenditcc.php
+++ b/opencart1.5.x/upload/catalog/controller/payment/xenditcc.php
@@ -31,7 +31,7 @@ class ControllerPaymentXenditCC extends Controller {
 
         $store_name = $this->config->get('config_name');
         $request_payload = array(
-            'external_id' => 'opencart_xendit_' . $order_id,
+            'external_id' => 'opencart-xendit-' . $order_id,
             'token_id' => $this->request->post['token_id'],
             'amount' => (int)$order['total'],
             'return_url' => $this->url->link('payment/xenditcc/process_3ds')
@@ -124,7 +124,7 @@ class ControllerPaymentXenditCC extends Controller {
                 'token_id' => $token_id,
                 'authentication_id' => $authentication_id,
                 'amount' => $amount,
-                'external_id' => 'opencart_xendit_' . $order_id,
+                'external_id' => 'opencart-xendit-' . $order_id,
             );
 
             $charge = Xendit::request(

--- a/opencart1.5.x/upload/catalog/model/payment/xendit.php
+++ b/opencart1.5.x/upload/catalog/model/payment/xendit.php
@@ -8,28 +8,36 @@ class ModelPaymentXendit extends Model
         return $method_data;
     }
 
-    public function addOrder($order_info, $invoice, $environment = 'test')
+    public function addOrder($order_info, $data, $environment = 'test', $type)
     {
-        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_order` SET 
-            `order_id` = '" . (int)$order_info['order_id'] . "',
-            `status` = 'PENDING',
-            `xendit_invoice_id` = '" . $invoice['id'] . "',
-            `xendit_expiry_date` = '" . $invoice['expiry_date'] . "',
-            `environment` = '" . $environment . "'");
+        $query = "  INSERT INTO `" . DB_PREFIX . "xendit_order` 
+                    SET `order_id`              = '" . $order_info['order_id'] . "',
+                        `external_id`           = '" . $data['external_id'] . "',
+                        `amount`                = '" . $data['amount'] . "',
+                        `payment_method`        = '" . $order_info['payment_method'] . "',
+                        `status`                = 'PENDING',
+                        `environment`           = '" . $environment . "'";
+        
+        if ($type == 'invoice') {
+            $query .= ",
+                        `xendit_invoice_id`     = '" . $data['id'] . "',
+                        `xendit_expiry_date`    = '" . $data['expiry_date'] . "'";
+        }
+        $this->db->query($query);
         return $this->db->getLastId();
     }
 
-    public function addCCOrder($order_id, $data, $environment = 'test')
+    public function completeOrder($order_id, $extra = '')
     {
-        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_charge` SET 
-            `order_id` = '" . (int)$order_id . "',
-            `xendit_charge_id` = '" . $data['id'] . "',
-            `environment` = '" . $environment . "'");
-        return $this->db->getLastId();
+        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
+                          SET `status` = 'COMPLETED', `xendit_paid_date` = NOW() $extra
+                          WHERE `order_id` = '" . $order_id . "'");
     }
 
-    public function completeOrder($order_id)
+    public function cancelOrder($order_id)
     {
-        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` SET `status` = 'COMPLETED' WHERE `order_id` = '" . $order_id . "'");
+        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
+                          SET `status` = 'FAILED', `xendit_cancelled_date` = NOW() 
+                          WHERE `order_id` = '" . $order_id . "'");
     }
 }

--- a/opencart1.5.x/upload/catalog/model/payment/xendit.php
+++ b/opencart1.5.x/upload/catalog/model/payment/xendit.php
@@ -8,9 +8,10 @@ class ModelPaymentXendit extends Model
         return $method_data;
     }
 
-    /*public function addOrder($order_info, $invoice, $environment = 'test')
+    public function addOrder($order_info, $invoice, $environment = 'test')
     {
-        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_order` SET `order_id` = '" . (int)$order_info['order_id'] . "',
+        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_order` SET 
+            `order_id` = '" . (int)$order_info['order_id'] . "',
             `status` = 'PENDING',
             `xendit_invoice_id` = '" . $invoice['id'] . "',
             `xendit_expiry_date` = '" . $invoice['expiry_date'] . "',
@@ -18,8 +19,17 @@ class ModelPaymentXendit extends Model
         return $this->db->getLastId();
     }
 
+    public function addCCOrder($order_id, $data, $environment = 'test')
+    {
+        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_charge` SET 
+            `order_id` = '" . (int)$order_id . "',
+            `xendit_charge_id` = '" . $data['id'] . "',
+            `environment` = '" . $environment . "'");
+        return $this->db->getLastId();
+    }
+
     public function completeOrder($order_id)
     {
         $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` SET `status` = 'COMPLETED' WHERE `order_id` = '" . $order_id . "'");
-    }*/
+    }
 }

--- a/opencart1.5.x/upload/catalog/model/payment/xendit.php
+++ b/opencart1.5.x/upload/catalog/model/payment/xendit.php
@@ -8,7 +8,7 @@ class ModelPaymentXendit extends Model
         return $method_data;
     }
 
-    public function addOrder($order_info, $data, $environment = 'test', $type)
+    public function addOrder($order_info, $data, $environment = 'test', $type = 'invoice')
     {
         $query = "  INSERT INTO `" . DB_PREFIX . "xendit_order` 
                     SET `order_id`              = '" . $order_info['order_id'] . "',
@@ -27,17 +27,24 @@ class ModelPaymentXendit extends Model
         return $this->db->getLastId();
     }
 
-    public function completeOrder($order_id, $extra = '')
+    public function paidOrder($order_id, $date, $extra = [])
     {
-        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
-                          SET `status` = 'PAID', `xendit_paid_date` = NOW() $extra
-                          WHERE `order_id` = '" . $order_id . "'");
+        $date = date("Y-m-d H:i:s", strtotime($date)); 
+        $query = "UPDATE `" . DB_PREFIX . "xendit_order` SET `status` = 'PAID', `xendit_paid_date` = '$date'";
+
+        foreach ($extra as $key => $value) {
+            $query .= ", `".$key."` = '".$value."'";
+        }
+
+        $query .= " WHERE `order_id` = '$order_id'";
+        $this->db->query($query);
     }
 
     public function cancelOrder($order_id)
     {
+        $date = gmdate("Y-m-d H:i:s");
         $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
-                          SET `status` = 'CANCELLED', `xendit_cancelled_date` = NOW() 
+                          SET `status` = 'CANCELLED', `xendit_cancelled_date` = '$date' 
                           WHERE `order_id` = '" . $order_id . "'");
     }
 }

--- a/opencart1.5.x/upload/catalog/model/payment/xendit.php
+++ b/opencart1.5.x/upload/catalog/model/payment/xendit.php
@@ -30,14 +30,14 @@ class ModelPaymentXendit extends Model
     public function completeOrder($order_id, $extra = '')
     {
         $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
-                          SET `status` = 'COMPLETED', `xendit_paid_date` = NOW() $extra
+                          SET `status` = 'PAID', `xendit_paid_date` = NOW() $extra
                           WHERE `order_id` = '" . $order_id . "'");
     }
 
     public function cancelOrder($order_id)
     {
         $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
-                          SET `status` = 'FAILED', `xendit_cancelled_date` = NOW() 
+                          SET `status` = 'CANCELLED', `xendit_cancelled_date` = NOW() 
                           WHERE `order_id` = '" . $order_id . "'");
     }
 }

--- a/opencart3.0.x/upload/admin/controller/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/admin/controller/extension/payment/xendit.php
@@ -126,61 +126,6 @@ class ControllerExtensionPaymentXendit extends Controller
         return true;
     }
 
-    public function cancelExpiredOrder($eventRoute, &$data)
-    {
-        $this->load->model('extension/payment/xendit');
-        $this->load->model('sale/order');
-
-        $bulk_cancel_data = array();
-        $expired_orders = $this->model_extension_payment_xendit->getExpiredOrders();
-
-        if ($expired_orders) {
-            foreach ($expired_orders as $xendit_order) {
-                $order_id = $xendit_order['order_id'];
-                $order = $this->model_sale_order->getOrder(
-                    $order_id
-                );
-    
-                $bulk_cancel_data[] = array(
-                    'id' => $xendit_order['xendit_invoice_id'],
-                    'expiry_date' => $xendit_order['xendit_expiry_date'],
-                    'order_number' => $order_id,
-                    'amount' => (int)$order['total']
-                );
-    
-                $this->model_extension_payment_xendit->expireOrder($order_id);
-                $this->model_extension_payment_xendit->addOrderHistory(
-                    $order,
-                    $order_id,
-                    7,
-                    'Order cancelled because Xendit invoice expired',
-                    false
-                );
-            }
-        }
-
-        if (!empty($bulk_cancel_data)) {
-            $response = $this->track_order_cancellation($bulk_cancel_data);
-        }
-    }
-
-    private function track_order_cancellation($payload)
-    {
-        $request_url = '/payment/xendit/invoice/bulk-cancel';
-        $request_payload = array(
-            'invoice_data' => json_encode($payload)
-        );
-        $request_options = array(
-            'store_name' => Xendit::DEFAULT_STORE_NAME
-        );
-
-        $api_key = $this->get_api_key();
-        Xendit::set_secret_key($api_key['secret_key']);
-
-        $response = Xendit::request($request_url, Xendit::METHOD_POST, $request_payload, $request_options);
-        return $response;
-    }
-
     private function get_api_key()
     {
         if ($this->config->get('payment_xendit_environment') === 'live') {

--- a/opencart3.0.x/upload/admin/model/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/admin/model/extension/payment/xendit.php
@@ -4,16 +4,16 @@ class ModelExtensionPaymentXendit extends Model {
     public function install() {
         $this->db->query("CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "xendit_order` (
             `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
-            `order_id` int(11) NOT NULL DEFAULT '0',
+            `order_id` int(11) NOT NULL,
             `external_id` varchar(255) NOT NULL,
             `amount` decimal(10,2) NOT NULL,
             `payment_method` varchar(255) NOT NULL,
-            `xendit_invoice_id` varchar(255) NOT NULL,
-            `xendit_invoice_fee` decimal(10,2) NOT NULL,
-            `xendit_charge_id` varchar(255) NOT NULL,
-            `xendit_paid_date` datetime NOT NULL,
-            `xendit_expiry_date` datetime NOT NULL,
-            `xendit_cancelled_date` datetime NOT NULL,
+            `xendit_invoice_id` varchar(255),
+            `xendit_invoice_fee` decimal(10,2),
+            `xendit_charge_id` varchar(255),
+            `xendit_paid_date` datetime,
+            `xendit_expiry_date` datetime,
+            `xendit_cancelled_date` datetime,
             `status` varchar(150) NOT NULL,
             `environment` varchar(5) NOT NULL DEFAULT 'test'
         ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");

--- a/opencart3.0.x/upload/admin/model/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/admin/model/extension/payment/xendit.php
@@ -1,18 +1,20 @@
 <?php
 
-class ModelExtensionPaymentXendit extends Model {
+class ModelPaymentXendit extends Model {
     public function install() {
         $this->db->query("CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "xendit_order` (
-            `xendit_invoice_id` varchar(255) NOT NULL PRIMARY KEY,
+            `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            `order_id` int(11) NOT NULL DEFAULT '0',
+            `external_id` varchar(255) NOT NULL,
+            `amount` decimal(10,2) NOT NULL,
+            `payment_method` varchar(255) NOT NULL,
+            `xendit_invoice_id` varchar(255) NOT NULL,
+            `xendit_invoice_fee` decimal(10,2) NOT NULL,
+            `xendit_charge_id` varchar(255) NOT NULL,
+            `xendit_paid_date` datetime NOT NULL,
             `xendit_expiry_date` datetime NOT NULL,
-            `status` varchar(255) NOT NULL,
-            `order_id` int(11) NOT NULL DEFAULT '0',
-            `environment` varchar(5) NOT NULL DEFAULT 'test'
-        ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
-
-        $this->db->query("CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "xendit_charge` (
-            `xendit_charge_id` varchar(255) NOT NULL PRIMARY KEY,
-            `order_id` int(11) NOT NULL DEFAULT '0',
+            `xendit_cancelled_date` datetime NOT NULL,
+            `status` varchar(150) NOT NULL,
             `environment` varchar(5) NOT NULL DEFAULT 'test'
         ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;");
     }

--- a/opencart3.0.x/upload/admin/model/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/admin/model/extension/payment/xendit.php
@@ -1,6 +1,6 @@
 <?php
 
-class ModelPaymentXendit extends Model {
+class ModelExtensionPaymentXendit extends Model {
     public function install() {
         $this->db->query("CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "xendit_order` (
             `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/opencart3.0.x/upload/admin/model/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/admin/model/extension/payment/xendit.php
@@ -33,29 +33,6 @@ class ModelExtensionPaymentXendit extends Model {
         }
     }
 
-    public function getOrderByInvoiceId($invoice_id) {
-        $query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "xendit_order` WHERE `xendit_invoice_id` = '" . $invoice_id . "' LIMIT 1");
-        if ($query->num_rows) {
-            return $query->row;
-        } else {
-            return false;
-        }
-    }
-
-    public function expireOrder($order_id) {
-        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` SET `status` = 'EXPIRED' WHERE `order_id` = '" . $order_id . "'");
-    }
-
-    public function getExpiredOrders() {
-        $query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "xendit_order` WHERE `xendit_expiry_date` < NOW() AND `status` = 'PENDING'");
-
-        if ($query->num_rows) {
-            return $query->rows;
-        } else {
-            return false;
-        }
-    }
-
     public function addOrderHistory($order_info, $order_id, $order_status_id, $comment = '') {
 		if ($order_info) {
 			// Update the DB with the new statuses

--- a/opencart3.0.x/upload/catalog/controller/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/catalog/controller/extension/payment/xendit.php
@@ -54,7 +54,7 @@ class ControllerExtensionPaymentXendit extends Controller {
                 $json['error'] = $response['message'];
             }
             else {
-                $this->model_extension_payment_xendit->addOrder($order, $response, $this->config->get('payment_xendit_environment'));
+                $this->model_extension_payment_xendit->addOrder($order, $response, $this->config->get('payment_xendit_environment'), 'invoice');
                 $message = 'Invoice ID: ' . $response['id'] . '. Redirecting..';
                 $this->model_checkout_order->addOrderHistory(
                     $order_id,
@@ -162,6 +162,7 @@ class ControllerExtensionPaymentXendit extends Controller {
 
     private function cancel_order($order_id, $message) {
         $this->cart->clear();
+        $this->model_extension_payment_xendit->cancelOrder($order_id);
         $this->model_checkout_order->addOrderHistory(
             $order_id,
             7,

--- a/opencart3.0.x/upload/catalog/controller/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/catalog/controller/extension/payment/xendit.php
@@ -3,7 +3,7 @@
 require_once(DIR_SYSTEM . 'library/xendit.php');
 
 class ControllerExtensionPaymentXendit extends Controller {
-    const EXT_ID_PREFIX = 'xendit_opencart_';
+    const EXT_ID_PREFIX = 'opencart-xendit-';
 
     public function index() {
         $this->load->language('extension/payment/xendit');

--- a/opencart3.0.x/upload/catalog/controller/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/catalog/controller/extension/payment/xendit.php
@@ -145,7 +145,7 @@ class ControllerExtensionPaymentXendit extends Controller {
     private function process_order($response, $order_id) {
         if ($response['status'] === 'PAID' || $response['status'] === 'SETTLED') {
             $this->cart->clear();
-            $message = 'Payment successful. Invoice id: ' . $response['id'];
+            $message = 'Payment successful. Invoice ID: ' . $response['id'];
             $this->model_extension_payment_xendit->completeOrder($order_id);
             $this->model_checkout_order->addOrderHistory(
                 $order_id,
@@ -155,7 +155,7 @@ class ControllerExtensionPaymentXendit extends Controller {
             );
             $this->response->setOutput($message);
         } else {
-            $message = 'Invoice not paid or settled. Cancelling order. Charge id: ' . $response['id'];
+            $message = 'Invoice not paid or settled. Cancelling order. Charge ID: ' . $response['id'];
             return $this->cancel_order($order_id, $message);
         }
     }

--- a/opencart3.0.x/upload/catalog/controller/extension/payment/xenditcc.php
+++ b/opencart3.0.x/upload/catalog/controller/extension/payment/xenditcc.php
@@ -29,7 +29,7 @@ class ControllerExtensionPaymentXenditCC extends Controller {
 
         $store_name = $this->config->get('config_name');
         $request_payload = array(
-            'external_id' => 'opencart_xendit_' . $order_id,
+            'external_id' => 'opencart-xendit-' . $order_id,
             'token_id' => $this->request->post['token_id'],
             'amount' => (int)$order['total'],
             'return_url' => $this->url->link('extension/payment/xenditcc/process_3ds')
@@ -131,7 +131,7 @@ class ControllerExtensionPaymentXenditCC extends Controller {
                 'token_id' => $token_id,
                 'authentication_id' => $authentication_id,
                 'amount' => $amount,
-                'external_id' => 'opencart_xendit_' . $order_id,
+                'external_id' => 'opencart-xendit-' . $order_id,
             );
 
             $charge = Xendit::request(

--- a/opencart3.0.x/upload/catalog/controller/extension/payment/xenditcc.php
+++ b/opencart3.0.x/upload/catalog/controller/extension/payment/xenditcc.php
@@ -181,7 +181,7 @@ class ControllerExtensionPaymentXenditCC extends Controller {
 
     private function process_order($charge, $order_id) {
         if ($charge['status'] !== 'CAPTURED') {
-            $message = 'Charge failed. Cancelling order. Charge id: ' . $charge['id'];
+            $message = 'Charge failed. Cancelling order. Charge ID: ' . $charge['id'];
             return $this->cancel_order($order_id, $message);
         }
         $this->cart->clear();

--- a/opencart3.0.x/upload/catalog/controller/extension/payment/xenditcc.php
+++ b/opencart3.0.x/upload/catalog/controller/extension/payment/xenditcc.php
@@ -3,6 +3,8 @@
 require_once(DIR_SYSTEM . 'library/xendit.php');
 
 class ControllerExtensionPaymentXenditCC extends Controller {
+    const EXT_ID_PREFIX = 'opencart-xendit-';
+
     public function index() {
         $this->load->language('extension/payment/xenditcc');
 
@@ -29,7 +31,7 @@ class ControllerExtensionPaymentXenditCC extends Controller {
 
         $store_name = $this->config->get('config_name');
         $request_payload = array(
-            'external_id' => 'opencart-xendit-' . $order_id,
+            'external_id' => self::EXT_ID_PREFIX . $order_id,
             'token_id' => $this->request->post['token_id'],
             'amount' => (int)$order['total'],
             'return_url' => $this->url->link('extension/payment/xenditcc/process_3ds')
@@ -131,7 +133,7 @@ class ControllerExtensionPaymentXenditCC extends Controller {
                 'token_id' => $token_id,
                 'authentication_id' => $authentication_id,
                 'amount' => $amount,
-                'external_id' => 'opencart-xendit-' . $order_id,
+                'external_id' => self::EXT_ID_PREFIX . $order_id,
             );
 
             $charge = Xendit::request(
@@ -172,13 +174,15 @@ class ControllerExtensionPaymentXenditCC extends Controller {
     private function process_order($charge, $order_id) {
         if ($charge['status'] !== 'CAPTURED') {
             $message = 'Charge failed. Cancelling order. Charge ID: ' . $charge['id'];
-            return $this->cancel_order($order_id, $message);
+            $this->cancel_order($order_id, $message);
+
+            $redir_url = $this->url->link('extension/payment/xenditcc/failure');
+            $this->response->redirect($redir_url);
+            return;
         }
         $this->cart->clear();
 
-        $this->model_extension_payment_xendit->completeOrder($order_id, 
-            ", `xendit_charge_id` = '". $charge['id'] . "'"
-        );
+        $this->model_extension_payment_xendit->paidOrder($order_id, $charge['created'], array('xendit_charge_id' => $charge['id']));
 
         $message = 'Payment successful. Charge ID: ' . $charge['id'];
         $this->model_checkout_order->addOrderHistory(

--- a/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
@@ -10,10 +10,20 @@ class ModelExtensionPaymentXendit extends Model
 
     public function addOrder($order_info, $invoice, $environment = 'test')
     {
-        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_order` SET `order_id` = '" . (int)$order_info['order_id'] . "',
+        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_order` SET 
+            `order_id` = '" . (int)$order_info['order_id'] . "',
             `status` = 'PENDING',
             `xendit_invoice_id` = '" . $invoice['id'] . "',
             `xendit_expiry_date` = '" . $invoice['expiry_date'] . "',
+            `environment` = '" . $environment . "'");
+        return $this->db->getLastId();
+    }
+
+    public function addCCOrder($order_id, $data, $environment = 'test')
+    {
+        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_charge` SET 
+            `order_id` = '" . (int)$order_id . "',
+            `xendit_charge_id` = '" . $data['id'] . "',
             `environment` = '" . $environment . "'");
         return $this->db->getLastId();
     }

--- a/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
@@ -30,14 +30,14 @@ class ModelExtensionPaymentXendit extends Model
     public function completeOrder($order_id, $extra = '')
     {
         $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
-                          SET `status` = 'COMPLETED', `xendit_paid_date` = NOW() $extra
+                          SET `status` = 'PAID', `xendit_paid_date` = NOW() $extra
                           WHERE `order_id` = '" . $order_id . "'");
     }
 
     public function cancelOrder($order_id)
     {
         $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
-                          SET `status` = 'FAILED', `xendit_cancelled_date` = NOW() 
+                          SET `status` = 'CANCELLED', `xendit_cancelled_date` = NOW() 
                           WHERE `order_id` = '" . $order_id . "'");
     }
 }

--- a/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
@@ -1,6 +1,6 @@
 <?php
 
-class ModelExtensionPaymentXendit extends Model
+class ModelPaymentXendit extends Model
 {
     public function getMethod($address, $total)
     {
@@ -8,28 +8,36 @@ class ModelExtensionPaymentXendit extends Model
         return $method_data;
     }
 
-    public function addOrder($order_info, $invoice, $environment = 'test')
+    public function addOrder($order_info, $data, $environment = 'test', $type)
     {
-        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_order` SET 
-            `order_id` = '" . (int)$order_info['order_id'] . "',
-            `status` = 'PENDING',
-            `xendit_invoice_id` = '" . $invoice['id'] . "',
-            `xendit_expiry_date` = '" . $invoice['expiry_date'] . "',
-            `environment` = '" . $environment . "'");
+        $query = "  INSERT INTO `" . DB_PREFIX . "xendit_order` 
+                    SET `order_id`              = '" . $order_info['order_id'] . "',
+                        `external_id`           = '" . $data['external_id'] . "',
+                        `amount`                = '" . $data['amount'] . "',
+                        `payment_method`        = '" . $order_info['payment_method'] . "',
+                        `status`                = 'PENDING',
+                        `environment`           = '" . $environment . "'";
+        
+        if ($type == 'invoice') {
+            $query .= ",
+                        `xendit_invoice_id`     = '" . $data['id'] . "',
+                        `xendit_expiry_date`    = '" . $data['expiry_date'] . "'";
+        }
+        $this->db->query($query);
         return $this->db->getLastId();
     }
 
-    public function addCCOrder($order_id, $data, $environment = 'test')
+    public function completeOrder($order_id, $extra = '')
     {
-        $this->db->query("INSERT INTO `" . DB_PREFIX . "xendit_charge` SET 
-            `order_id` = '" . (int)$order_id . "',
-            `xendit_charge_id` = '" . $data['id'] . "',
-            `environment` = '" . $environment . "'");
-        return $this->db->getLastId();
+        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
+                          SET `status` = 'COMPLETED', `xendit_paid_date` = NOW() $extra
+                          WHERE `order_id` = '" . $order_id . "'");
     }
 
-    public function completeOrder($order_id)
+    public function cancelOrder($order_id)
     {
-        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` SET `status` = 'COMPLETED' WHERE `order_id` = '" . $order_id . "'");
+        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
+                          SET `status` = 'FAILED', `xendit_cancelled_date` = NOW() 
+                          WHERE `order_id` = '" . $order_id . "'");
     }
 }

--- a/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
@@ -1,6 +1,6 @@
 <?php
 
-class ModelPaymentXendit extends Model
+class ModelExtensionPaymentXendit extends Model
 {
     public function getMethod($address, $total)
     {

--- a/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
+++ b/opencart3.0.x/upload/catalog/model/extension/payment/xendit.php
@@ -8,7 +8,7 @@ class ModelExtensionPaymentXendit extends Model
         return $method_data;
     }
 
-    public function addOrder($order_info, $data, $environment = 'test', $type)
+    public function addOrder($order_info, $data, $environment = 'test', $type = 'invoice')
     {
         $query = "  INSERT INTO `" . DB_PREFIX . "xendit_order` 
                     SET `order_id`              = '" . $order_info['order_id'] . "',
@@ -27,17 +27,24 @@ class ModelExtensionPaymentXendit extends Model
         return $this->db->getLastId();
     }
 
-    public function completeOrder($order_id, $extra = '')
+    public function paidOrder($order_id, $date, $extra = [])
     {
-        $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
-                          SET `status` = 'PAID', `xendit_paid_date` = NOW() $extra
-                          WHERE `order_id` = '" . $order_id . "'");
+        $date = date("Y-m-d H:i:s", strtotime($date)); 
+        $query = "UPDATE `" . DB_PREFIX . "xendit_order` SET `status` = 'PAID', `xendit_paid_date` = '$date'";
+
+        foreach ($extra as $key => $value) {
+            $query .= ", `".$key."` = '".$value."'";
+        }
+
+        $query .= " WHERE `order_id` = '$order_id'";
+        $this->db->query($query);
     }
 
     public function cancelOrder($order_id)
     {
+        $date = gmdate("Y-m-d H:i:s");
         $this->db->query("UPDATE `" . DB_PREFIX . "xendit_order` 
-                          SET `status` = 'CANCELLED', `xendit_cancelled_date` = NOW() 
+                          SET `status` = 'CANCELLED', `xendit_cancelled_date` = '$date' 
                           WHERE `order_id` = '" . $order_id . "'");
     }
 }

--- a/opencart3.0.x/upload/catalog/view/theme/default/template/extension/payment/xendit.twig
+++ b/opencart3.0.x/upload/catalog/view/theme/default/template/extension/payment/xendit.twig
@@ -56,11 +56,11 @@
 <style>
     .test_instructions {
         color: #E61616;
-        font-size: 18px;
+        font-size: 14px;
         margin-bottom: 4px;
     }
 
     .instructions {
-        font-size: 18px;
+        font-size: 14px;
     }
 </style>

--- a/opencart3.0.x/upload/catalog/view/theme/default/template/extension/payment/xenditcc.twig
+++ b/opencart3.0.x/upload/catalog/view/theme/default/template/extension/payment/xenditcc.twig
@@ -32,7 +32,7 @@
                                 autofocus=""
                                 maxlength="16"
                                 onkeyup="this.value=this.value.replace(/[^\d\/]/g,'')"
-                                style="font-size: 18px;"
+                                style="font-size: 14px;"
                         >
                     </div>
                 </div>
@@ -49,7 +49,7 @@
                                 maxlength="5"
                                 size="5"
                                 onkeyup="this.value=this.value.replace(/^(\d\d)(\d)$/g,'$1/$2').replace(/^(\d\d\/\d\d)(\d+)$/g,'$1/$2').replace(/[^\d\/]/g,'')"
-                                style="font-size: 18px;"
+                                style="font-size: 14px;"
                         >
                     </div>
                 </div>
@@ -64,7 +64,7 @@
                                 required
                                 maxlength="4"
                                 onkeyup="this.value=this.value.replace(/[^\d\/]/g,'')"
-                                style="font-size: 18px;"
+                                style="font-size: 14px;"
                         >
                     </div>
                 </div>
@@ -147,11 +147,11 @@
 <style>
     .test_instructions {
         color: #E61616;
-        font-size: 18px;
+        font-size: 14px;
         margin-bottom: 4px;
     }
 
     .instructions {
-        font-size: 18px;
+        font-size: 14px;
     }
 </style>


### PR DESCRIPTION
OC 1.5:
- Invoice order are now inserted to oc_xendit_order
- CC orders are now inserted to oc_xendit_order
- Refactor `external_id` prefix = `opencart-xendit-`

OC 3.0:
- Invoice order are now inserted to oc_xendit_order
- CC orders are now inserted to oc_xendit_order
- Refactor `external_id` prefix = `opencart-xendit-`
- Font size reduced to 14px

* No more table oc_xendit_charge